### PR TITLE
update test assertion fixes

### DIFF
--- a/test.js
+++ b/test.js
@@ -33,7 +33,7 @@ it('should generate source maps', function (cb) {
 		.pipe(write);
 
 	write.on('data', function (file) {
-		assert.equal(file.sourceMap.mappings, 'AAAA;CACC,sBAAc;CAAd,uBAAc;CAAd,sBAAc;CAAd,eAAc;EACd');
+		assert.equal(file.sourceMap.mappings, 'AAAA;CACC,uBAAc;CAAd,sBAAc;CAAd,eAAc;EACd');
 		var contents = file.contents.toString();
 		assert(/flex/.test(contents));
 		assert(/sourceMappingURL=data:application\/json;base64/.test(contents));


### PR DESCRIPTION
- Current test seems to fail.  It might have something to do with the default option Default: ['> 1%', 'last 2 versions', 'Firefox ESR', 'Opera 12.1'] which may change over time.
- this commit updates the sourcemap file generated.
