### PR TITLE
Allows inline & other supported map options.

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,10 +21,17 @@ module.exports = function (opts) {
 
 		var res;
 		var fileOpts = objectAssign({}, opts);
+		var map = false;
+		 
 
 		try {
+			if (fileOpts.map) {
+				map = fileOpts.map
+			} else {
+				map = file.sourceMap ? {annotation: false} : false
+			}
 			res = autoprefixer(fileOpts).process(file.contents.toString(), {
-				map: file.sourceMap ? {annotation: false} : false,
+				map: map,
 				from: file.relative,
 				to: file.relative
 			});


### PR DESCRIPTION
There was a bug where gulp-autoprefixer would remove inline source maps from my gulp-sass plugin since it doesn't produce external sourcemaps. So now it can check for the option and use that value otherwise do what it did before.

So you can send:

```
autoprefix({
     browsers: ['last 2 versions'],
     map: 'inline' // Or any support autoprefixer-core processor -> map variables
})
```
