### PR TITLE
Update to use normal source map

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,9 +32,22 @@ module.exports = function (opts) {
 			file.contents = new Buffer(res.css);
 
 			if (res.map && file.sourceMap) {
-				applySourceMap(file, res.map.toString());
-			}
+				var resMap = JSON.parse(res.map.toString());
+				var origMap = file.sourceMap;
+				if (!origMap.sources) {
+					origMap.sources = [];
+				}
+				origMap.sources.push(file.path);
 
+				if (!origMap.sourcesContent) {
+					origMap.sourcesContent = [];
+				}
+				var index = origMap.sources.length - 1;
+				origMap.sourcesContent[index] = file.contents.toString();
+				
+				origMap.mappings += resMap.mappings;
+			}
+			
 			cb(null, file);
 		} catch (err) {
 			cb(new gutil.PluginError('gulp-autoprefixer', err, {fileName: file.path}));


### PR DESCRIPTION
With this update we can compile a correct source map, i.e.:

return gulp.src('src/*_/_.less')
  .pipe(plumber())
  .pipe(sourceMaps.init())
  .pipe(less())
  .pipe(prefix({
    browsers: ['last 2 versions']
  }))
  .pipe(sourceMaps.write())
  .pipe(gulp.dest('dist'));
