### PR TITLE
Update `autoprefixer-core` to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "preprocess"
   ],
   "dependencies": {
-    "autoprefixer-core": "^3.0.1",
+    "autoprefixer-core": "^3.1.2",
     "gulp-util": "^3.0.0",
     "object-assign": "^1.0.0",
     "through2": "^0.6.2",


### PR DESCRIPTION
Closes #15. It's not really needed, but I will avoid people thinking or opening issues because it's outdated.
