### PR TITLE
Add backwards compatibility with previous versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ var objectAssign = require('object-assign');
 
 module.exports = function (opts) {
 	opts = opts || {};
+	// Backwards compatibility with older versions.
+	if (typeof opts === "string") {
+		opts = { browsers: [].slice.call(arguments) };
+	}
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {


### PR DESCRIPTION
If just a string or series of strings is passed to the plugin, we convert it to an object.

Fixes #18
