### PR TITLE
avoid possible double-call to cb() function on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,8 +40,10 @@ module.exports = function (opts) {
 				gutil.log('gulp-autoprefixer:', '\n  ' + warnings.join('\n  '));
 			}
 
+		}).then(function () {
 			cb(null, file);
-		}).catch(function (err) {
+
+		}, function (err) {
 			var cssError = err.name === 'CssSyntaxError';
 
 			if (cssError) {


### PR DESCRIPTION
This solves a problem for some users where an error earlier in the pipe can cause the cb() function to throw an exception, leading to a double call in the fail handler for the processor promise.