### PR TITLE
Do not modify original sourceMap.sources and sourceMap.file

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function (opts) {
 		var processor = postcss()
 			.use(autoprefixer(fileOpts))
 			.process(file.contents.toString(), {
-				map: file.sourceMap ? {annotation: false} : false,
+				map: file.sourceMap ? {annotation: false, prev: JSON.stringify(file.sourceMap)} : false,
 				from: file.path,
 				to: file.path
 			});
@@ -31,7 +31,11 @@ module.exports = function (opts) {
 			file.contents = new Buffer(res.css);
 
 			if (res.map && file.sourceMap) {
+				var originalFile = file.sourceMap.file;
+				var originalSources = file.sourceMap.sources;
 				applySourceMap(file, res.map.toString());
+				file.sourceMap.file = originalFile;
+				file.sourceMap.sources = originalSources;
 			}
 
 			var warnings = res.warnings();


### PR DESCRIPTION
Currently if you have some source map before running autoprefixer it will be broken: 

Before autoprefixer:

```json
{
"file": "dist/style.css",
"sources": [ "some/dir/style.less" ]
}
```

After autoprefixer:

```json
{
"file": "style.css",
"sources": [ "style.less" ]
}
```