### PR TITLE
Fixes issue #46

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 'use strict';
+
+require('es6-promise').polyfill();
+
 var gutil = require('gulp-util');
 var through = require('through2');
 var applySourceMap = require('vinyl-sourcemaps-apply');

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "dependencies": {
     "autoprefixer": "^6.0.0",
+    "es6-promise": "^3.0.2",
     "gulp-util": "^3.0.0",
     "postcss": "^5.0.4",
     "through2": "^2.0.0",


### PR DESCRIPTION
`postcss` uses the promise api which is not available in node versions prior to `v0.12`. this pr adds a polyfill for that api and closes issue #46  