### PR TITLE
Include existing Source Maps when passing options to Autoprefixer / P…

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function (opts) {
 		}
 
 		postcss(autoprefixer(opts)).process(file.contents.toString(), {
-			map: file.sourceMap ? {annotation: false, prev:file.sourceMap} : false,
+			map: file.sourceMap ? {annotation: false, prev: file.sourceMap} : false,
 			from: file.path,
 			to: file.path
 		}).then(function (res) {

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function (opts) {
 		}
 
 		postcss(autoprefixer(opts)).process(file.contents.toString(), {
-			map: file.sourceMap ? {annotation: false} : false,
+			map: file.sourceMap ? {annotation: false, prev:file.sourceMap} : false,
 			from: file.path,
 			to: file.path
 		}).then(function (res) {


### PR DESCRIPTION
…ostCSS.

I'm new to the pull requests and contributing to the codebase of others. Please let me know if I've left out expected information or missed a common developer courtesy. My intent is to provide information about how I arrived at proposing this change.
# TL;DR

For a few builds I've had some issues with CSS sourcemaps not pointing to the correct SASS files when `gulp-autoprefixer` is used. `gulp-sass` is being used in this case, but initial tests with `gulp-ruby-sass`, `gulp-less`, `gulp-myth`, and `gulp-stylus` seemed to be consistent. If problems persist, I'll go back and do more thorough checks with them.

A small change will generate correct sourcemaps when they already exist on a given file. It has to do with passing existing sourcemaps to PostCSS.

[Line 21 in `gulp-autoprefixer`](https://github.com/sindresorhus/gulp-autoprefixer/blob/v3.1.0/index.js#L21):

``` diff
--  map: file.sourceMap ? {annotation: false} : false,
++  map: file.sourceMap ? {annotation: false, prev: file.sourceMap} : false,
```
# Details (the long version)
## The ByScript "fix"

There were a couple work-arounds out there, but the one that seemed to return frequently in my search is an issue in the `gulp-sourcemaps` repository by @floridoo . https://github.com/floridoo/gulp-sourcemaps/issues/60

The user @ByScripts came up with the solution to write inline source map comments and then load them again. The modification to your task looks similar to the following:

``` javascript
    .pipe($.sourcemaps.write({includeContent: false}))
    .pipe($.sourcemaps.init({loadMaps: true}))
```

This doesn't work as you'd expect it to. The original comment never gets cleaned up by `convert-source-map` (https://github.com/floridoo/gulp-sourcemaps/blob/v1.6.0/index.js#L41-L49) because the files that are being worked with still have a `file.sourceMap` property (https://github.com/floridoo/gulp-sourcemaps/blob/v1.6.0/index.js#L20-L23).

The reason it appeared to work is the original inline comment still existed in the file and that is what the browser was picking up, but it was never being updated appropriately as it moved down the line and would lead to multiple `sourceMappingURL` comments. To confirm this, a small local module can be used:

``` javascript

// THE PLUGIN

const through = require('through2');

module.exports = function removeSourcemapProperty(){
    function removeGulpSourcemapProperty(file, encoding, callback){
        if (file.sourceMap) {
            delete file.sourceMap;
        }
        this.push(file);
        return callback();
    }
    return through.obj(removeGulpSourcemapProperty);
}

// THE PIPES

    .pipe($.sourcemaps.write({includeContent: false}))
    .pipe(removeSourcemapProperty())
    .pipe($.sourcemaps.init({loadMaps: true}))
```

The comment gets correctly removed and the sourcemaps are back to (correctly?) being broken.
## The _source_ of the problem.

The next step was to log the state of `file.sourceMap` and related variables as it passed through `gulp-sourcemaps` and `gulp-autoprefixer`. I arrived here: https://github.com/sindresorhus/gulp-autoprefixer/blob/v3.1.0/index.js#L21. My search brought me directly to the `autoprefixer` and `postcss` repositories where I found the following document: https://github.com/postcss/postcss/blob/5.1.0/docs/source-maps.md.

This lead to adding the `prev` property in Line 21 in `gulp-autoprefixer`:

``` diff
--  map: file.sourceMap ? {annotation: false} : false,
++  map: file.sourceMap ? {annotation: false, prev: file.sourceMap} : false,
```

And everything now appears to work as expected.
