### PR TITLE
Update sourcemap paths to be relative to `file.base`

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,9 +28,7 @@ module.exports = opts => {
 			if (res.map && file.sourceMap) {
 				const map = res.map.toJSON();
 				map.file = file.relative;
-				map.sources = map.sources.map(() => {
-					return file.relative;
-				});
+				map.sources = map.sources.map(() => file.relative);
 				applySourceMap(file, map);
 			}
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,12 @@ module.exports = opts => {
 			file.contents = Buffer.from(res.css);
 
 			if (res.map && file.sourceMap) {
-				applySourceMap(file, res.map.toString());
+				const map = res.map.toJSON();
+				map.file = file.relative;
+				map.sources = map.sources.map(() => {
+					return file.relative;
+				});
+				applySourceMap(file, map);
 			}
 
 			const warnings = res.warnings();


### PR DESCRIPTION
From https://www.npmjs.com/package/gulp-sourcemaps
 - Important: Make sure the paths in the generated source map (file and sources) are relative to file.base (e.g. use file.relative).

Fixes #55 