### PR TITLE
Upgrade to Autoprefixer 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "postcss-runner"
   ],
   "dependencies": {
-    "autoprefixer": "^7.0.0",
+    "autoprefixer": "^8.0.0",
     "fancy-log": "^1.3.2",
     "plugin-error": "^0.1.2",
     "postcss": "^6.0.1",

--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ test('autoprefix CSS', async t => {
 		cwd: __dirname,
 		base: path.join(__dirname, 'fixture'),
 		path: path.join(__dirname, 'fixture', 'fixture.css'),
-		contents: Buffer.from('a {\n\tdisplay: flex;\n}')
+		contents: Buffer.from('::placeholder {\n\tcolor: gray;\n}')
 	}));
 
 	const file = await data;


### PR DESCRIPTION
I had to change the tests due to the changes in `Browserslist` 3.0.0:

> In another hand, we remove dead browsers from default browsers. The dead browser is a browser with < than 1% in the global market and who don’t have security updates. Right now IE 10 and BlackBerry browser are dead browsers.

The test with `display: flex` didn't get prefixed by default anymore for that reason, so I changed the test.