### PR TITLE
Update to Autoprefixer 8.5 to add grid-gap support for IE 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "postcss-runner"
   ],
   "dependencies": {
-    "autoprefixer": "^8.0.0",
+    "autoprefixer": "^8.5.1",
     "fancy-log": "^1.3.2",
     "plugin-error": "^1.0.1",
     "postcss": "^6.0.1",


### PR DESCRIPTION
Autoprefixer 8.5 supports grid-gap for IE 11.
Check [Autoprefixer Releases](https://github.com/postcss/autoprefixer/releases) for detail.