### PR TITLE
Remove Node.js 4.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - '8'
   - '6'
-  - '4'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=4.5"
+    "node": ">=6.0"
   },
   "scripts": {
     "test": "xo && ava"


### PR DESCRIPTION
Node.js 4 was EOL on Apr 30.
Refs: https://github.com/nodejs/Release#release-schedule