### PR TITLE
Bump autoprefixer and PostCSS versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
 		"postcss-runner"
 	],
 	"dependencies": {
-		"autoprefixer": "^9.6.1",
+		"autoprefixer": "^10.2.6",
 		"fancy-log": "^1.3.2",
 		"plugin-error": "^1.0.1",
-		"postcss": "^7.0.17",
+		"postcss": "^8.3.0",
 		"through2": "^3.0.1",
 		"vinyl-sourcemaps-apply": "^0.2.1"
 	},


### PR DESCRIPTION
This fixes #118

I'm a big fan of this - it really saves me so much time! I noticed earlier you had rejected a PR that bumped versions in the package.json; however, I don't think your response (#114) is working out as you'd expect, since two of these dependencies (`autoprefixer` and `postcss`) aren't updating themselves correctly (I'm thinking it might be because it's a major version change? Unclear). Regardless, these pass the built-in tests, so I don't see an issue in doing this? Let me know if I'm mistaken!

Cheers,
Alex